### PR TITLE
Remove flatmap-stream vulnerability

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,8 @@ values:
 | ratio | width / height |
 | width | cropper frame width |
 | height | cropper frame height |
-| originX | cropper original position(x axis), accroding to image left|
-| originY | cropper original position(Y axis), accroding to image top|
+| originX | cropper original position(x axis), accroding to image left |
+| originY | cropper original position(Y axis), accroding to image top |
 | fixedRatio | turn on/off fixed ratio (bool default true) |
 | allowNewSelection | allow user to create a new selection instead of reusing initial selection (bool default true) |
 | styles | specify styles to override inline styles |

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com",
   "dependencies": {
     "deep-extend": "^0.4.1",
-    "npm-run-all": "^4.1.1",
+    "npm-run-all": "^4.1.5",
     "prop-types": "^15.6.0",
     "react": "^16.2.0",
     "react-dom": "^16.2.0"


### PR DESCRIPTION
An older version of `npm-run-all` is dependant on `flatmap-stream` which was hijacked by a malicious maintainer (see: https://github.com/mysticatea/npm-run-all/commit/57d72eb98c2ce108f07d2a2cf1b44d57f08ec3ca#commitcomment-31468478).

Right now, this package won't even install since NPM has removed the infected dependency: https://www.npmjs.com/package/flatmap-stream (leads to 404)

I've bumped the version of `npm-run-all` to `4.1.5` which removes the dependency on `flatmap-stream`.

Signed-off-by: Tristan Edwards <tristan.edwards@me.com>